### PR TITLE
Update pricing plans with new tiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,11 +603,11 @@
                     </ul>
                     <button class="btn" onclick="selectPlan('free')">Get Started</button>
                 </div>
-                
+
                 <div class="pricing-card popular">
                     <div class="popular-badge">Most Popular</div>
-                    <h3>Pro</h3>
-                    <div class="price">$9.99<span style="font-size: 1rem;">/month</span></div>
+                    <h3>Pro Monthly</h3>
+                    <div class="price">$49<span style="font-size: 1rem;">/month</span></div>
                     <ul class="features">
                         <li>100 documents per month</li>
                         <li>Advanced optimization</li>
@@ -616,12 +616,26 @@
                         <li>Priority support</li>
                         <li>API access</li>
                     </ul>
-                    <button class="btn" onclick="selectPlan('pro')">Upgrade to Pro</button>
+                    <button class="btn" onclick="selectPlan('pro-monthly')">Upgrade to Pro</button>
                 </div>
-                
+
                 <div class="pricing-card">
-                    <h3>Business</h3>
-                    <div class="price">$29.99<span style="font-size: 1rem;">/month</span></div>
+                    <h3>Pro Annual</h3>
+                    <div class="price">$299<span style="font-size: 1rem;">/year</span></div>
+                    <ul class="features">
+                        <li>100 documents per month</li>
+                        <li>Advanced optimization</li>
+                        <li>All formats supported</li>
+                        <li>Batch processing</li>
+                        <li>Priority support</li>
+                        <li>API access</li>
+                    </ul>
+                    <button class="btn" onclick="selectPlan('pro-annual')">Upgrade &amp; Save</button>
+                </div>
+
+                <div class="pricing-card">
+                    <h3>Business Annual</h3>
+                    <div class="price">$499<span style="font-size: 1rem;">/year</span></div>
                     <ul class="features">
                         <li>Unlimited documents</li>
                         <li>Team collaboration</li>
@@ -630,7 +644,7 @@
                         <li>24/7 support</li>
                         <li>Custom integrations</li>
                     </ul>
-                    <button class="btn" onclick="selectPlan('business')">Contact Sales</button>
+                    <button class="btn" onclick="selectPlan('business-annual')">Contact Sales</button>
                 </div>
             </div>
         </section>
@@ -640,28 +654,39 @@
             <div class="modal-overlay" onclick="closeLimitModal()"></div>
             <h2>🚀 Upgrade to Continue</h2>
             <p>You've used your free document today! Upgrade to process more documents.</p>
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 30px;">
+            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 30px;">
                 <div class="pricing-card">
-                    <h3>Pro</h3>
-                    <div class="price">$9.99<span style="font-size: 1rem;">/month</span></div>
+                    <h3>Pro Monthly</h3>
+                    <div class="price">$49<span style="font-size: 1rem;">/month</span></div>
                     <ul class="features">
                         <li>100 documents/month</li>
                         <li>All formats</li>
                         <li>Batch processing</li>
                         <li>Priority support</li>
                     </ul>
-                    <button class="btn" onclick="selectPlan('pro')">Upgrade Now</button>
+                    <button class="btn" onclick="selectPlan('pro-monthly')">Upgrade Now</button>
                 </div>
                 <div class="pricing-card">
-                    <h3>Business</h3>
-                    <div class="price">$29.99<span style="font-size: 1rem;">/month</span></div>
+                    <h3>Pro Annual</h3>
+                    <div class="price">$299<span style="font-size: 1rem;">/year</span></div>
+                    <ul class="features">
+                        <li>100 documents/month</li>
+                        <li>All formats</li>
+                        <li>Batch processing</li>
+                        <li>Priority support</li>
+                    </ul>
+                    <button class="btn" onclick="selectPlan('pro-annual')">Upgrade &amp; Save</button>
+                </div>
+                <div class="pricing-card">
+                    <h3>Business Annual</h3>
+                    <div class="price">$499<span style="font-size: 1rem;">/year</span></div>
                     <ul class="features">
                         <li>Unlimited documents</li>
                         <li>Team features</li>
                         <li>API access</li>
                         <li>24/7 support</li>
                     </ul>
-                    <button class="btn" onclick="selectPlan('business')">Contact Sales</button>
+                    <button class="btn" onclick="selectPlan('business-annual')">Contact Sales</button>
                 </div>
             </div>
             <button onclick="closeLimitModal()" style="margin-top: 20px; background: #ccc; color: #666; border: none; padding: 10px 20px; border-radius: 5px; cursor: pointer;">Maybe Later</button>
@@ -1123,35 +1148,38 @@
                 alert('You are now using the free plan! Process 1 document per day.');
                 return;
             }
-            
-            if (plan === 'business') {
+
+            if (!currentUser) {
+                alert('Please sign in first to upgrade your plan.');
+                return;
+            }
+
+            let priceId = '';
+            if (plan === 'pro-monthly') {
+                priceId = 'price_monthly_49';
+            } else if (plan === 'pro-annual') {
+                priceId = 'price_yearly_299';
+            } else if (plan === 'business-annual') {
+                priceId = 'price_business_499';
+            } else {
                 alert('Please contact sales@documentpro.com for business inquiries.');
                 return;
             }
-            
-            if (plan === 'pro') {
-                if (!currentUser) {
-                    alert('Please sign in first to upgrade your plan.');
-                    return;
+
+            stripe.redirectToCheckout({
+                lineItems: [{
+                    price: priceId,
+                    quantity: 1,
+                }],
+                mode: 'subscription',
+                customerEmail: currentUser.email,
+                successUrl: window.location.origin + '/success.html',
+                cancelUrl: window.location.origin + '/cancel.html',
+            }).then(function (result) {
+                if (result.error) {
+                    alert('Payment failed: ' + result.error.message);
                 }
-                
-                const priceId = 'price_1234567890'; // Replace with your price ID
-                
-                stripe.redirectToCheckout({
-                    lineItems: [{
-                        price: priceId,
-                        quantity: 1,
-                    }],
-                    mode: 'subscription',
-                    customerEmail: currentUser.email,
-                    successUrl: window.location.origin + '/success.html',
-                    cancelUrl: window.location.origin + '/cancel.html',
-                }).then(function (result) {
-                    if (result.error) {
-                        alert('Payment failed: ' + result.error.message);
-                    }
-                });
-            }
+            });
         }
 
         window.addEventListener('load', function() {


### PR DESCRIPTION
## Summary
- update pricing section with monthly and annual plans
- show new options in upgrade modal
- update Stripe price IDs in `selectPlan`

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f7e766ae0832bac6974c8e59fd6a7