### PR TITLE
Add legal and status pages

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Payment Cancelled - Document Pro</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#f8f9ff; text-align:center; padding:60px; }
+        a.button { display:inline-block; margin-top:30px; padding:12px 30px; background:#667eea; color:#fff; border-radius:8px; text-decoration:none; }
+    </style>
+</head>
+<body>
+    <h1>Payment Cancelled</h1>
+    <p>Your payment was cancelled or failed. You can return to the app and try again whenever you're ready.</p>
+    <a class="button" href="index.html">Back to Document Pro</a>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact Us - Document Pro</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#f8f9ff; padding:40px; max-width:800px; margin:auto; }
+        h1 { text-align:center; }
+        a.button { display:block; width:200px; margin:40px auto; padding:12px 30px; text-align:center; background:#667eea; color:#fff; border-radius:8px; text-decoration:none; }
+    </style>
+</head>
+<body>
+    <h1>Contact Us</h1>
+    <p>If you have any questions or need assistance, reach us at <a href="mailto:support@documentpro.com">support@documentpro.com</a> or call +1-800-123-4567.</p>
+    <a class="button" href="index.html">Back to Document Pro</a>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -678,9 +678,9 @@
                     <h4>Quick Links</h4>
                     <ul>
                         <li><a href="#signIn">Sign In</a></li>
-                        <li><a href="/terms.html">Terms of Service</a></li>
-                        <li><a href="/privacy.html">Privacy Policy</a></li>
-                        <li><a href="/contact.html">Contact Us</a></li>
+                        <li><a href="terms.html">Terms of Service</a></li>
+                        <li><a href="privacy.html">Privacy Policy</a></li>
+                        <li><a href="contact.html">Contact Us</a></li>
                     </ul>
                 </div>
                 <div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Document Pro</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#f8f9ff; padding:40px; max-width:800px; margin:auto; }
+        h1 { text-align:center; }
+        a.button { display:block; width:200px; margin:40px auto; padding:12px 30px; text-align:center; background:#667eea; color:#fff; border-radius:8px; text-decoration:none; }
+    </style>
+</head>
+<body>
+    <h1>Privacy Policy</h1>
+    <p>We respect your privacy and take protecting it seriously. This page outlines how we handle your data when using Document Pro. Replace this text with your detailed privacy policy.</p>
+    <a class="button" href="index.html">Back to Document Pro</a>
+</body>
+</html>

--- a/success.html
+++ b/success.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Payment Success - Document Pro</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#f8f9ff; text-align:center; padding:60px; }
+        a.button { display:inline-block; margin-top:30px; padding:12px 30px; background:#667eea; color:#fff; border-radius:8px; text-decoration:none; }
+    </style>
+</head>
+<body>
+    <h1>Payment Successful!</h1>
+    <p>Thank you for upgrading to Document Pro. You can now enjoy all premium features.</p>
+    <a class="button" href="index.html">Back to Document Pro</a>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - Document Pro</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#f8f9ff; padding:40px; max-width:800px; margin:auto; }
+        h1 { text-align:center; }
+        a.button { display:block; width:200px; margin:40px auto; padding:12px 30px; text-align:center; background:#667eea; color:#fff; border-radius:8px; text-decoration:none; }
+    </style>
+</head>
+<body>
+    <h1>Terms of Service</h1>
+    <p>Use Document Pro in accordance with all applicable laws. By using this site you agree to our policies and conditions. This page contains a basic overview of our terms. Replace with your full legal terms as needed.</p>
+    <a class="button" href="index.html">Back to Document Pro</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add payment success page with navigation back to main app
- add payment cancel page
- add simple terms of service, privacy policy, and contact pages
- point footer links to these new pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f7e7902a8832bbee9356fb475e319