### PR TITLE
Add Express backend and Stripe integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1134,23 +1134,23 @@
                     alert('Please sign in first to upgrade your plan.');
                     return;
                 }
-                
+
                 const priceId = 'price_1234567890'; // Replace with your price ID
-                
-                stripe.redirectToCheckout({
-                    lineItems: [{
-                        price: priceId,
-                        quantity: 1,
-                    }],
-                    mode: 'subscription',
-                    customerEmail: currentUser.email,
-                    successUrl: window.location.origin + '/success.html',
-                    cancelUrl: window.location.origin + '/cancel.html',
-                }).then(function (result) {
-                    if (result.error) {
-                        alert('Payment failed: ' + result.error.message);
+
+                fetch('/api/create-checkout-session', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ priceId: priceId, email: currentUser.email })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.id) {
+                        stripe.redirectToCheckout({ sessionId: data.id });
+                    } else if (data.error) {
+                        alert('Payment failed: ' + data.error);
                     }
-                });
+                })
+                .catch(err => alert('Payment failed: ' + err.message));
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "documenteditgpt-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2",
+    "stripe": "^12.11.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,92 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const bcrypt = require('bcrypt');
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY || '');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(bodyParser.json());
+
+// In-memory users and subscription status
+const users = {};
+const subscriptions = {};
+
+// User registration
+app.post('/api/register', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password required' });
+  }
+  if (users[email]) {
+    return res.status(400).json({ error: 'User already exists' });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  users[email] = { email, password: hashed };
+  res.json({ message: 'Registered successfully' });
+});
+
+// User login
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = users[email];
+  if (!user) {
+    return res.status(400).json({ error: 'Invalid credentials' });
+  }
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) {
+    return res.status(400).json({ error: 'Invalid credentials' });
+  }
+  res.json({ message: 'Login successful' });
+});
+
+// Create Stripe Checkout session
+app.post('/api/create-checkout-session', async (req, res) => {
+  const { priceId, email } = req.body;
+  if (!priceId || !email) {
+    return res.status(400).json({ error: 'priceId and email required' });
+  }
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      customer_email: email,
+      success_url: `${req.headers.origin}/success.html`,
+      cancel_url: `${req.headers.origin}/cancel.html`,
+    });
+    res.json({ id: session.id });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Stripe webhook handler
+app.post('/webhook', bodyParser.raw({ type: 'application/json' }), (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET || '');
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    subscriptions[session.customer_email] = 'active';
+  }
+  if (event.type === 'customer.subscription.deleted') {
+    const sub = event.data.object;
+    if (sub.customer_email) {
+      subscriptions[sub.customer_email] = 'canceled';
+    }
+  }
+  res.json({ received: true });
+});
+
+// Serve static frontend
+app.use(express.static(path.join(__dirname)));
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- implement `server.js` with Express, registration/login APIs and Stripe checkout
- update `index.html` to obtain session ID from backend
- add `package.json` for server dependencies

## Testing
- `npm test` *(fails: missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f7e783244832ba5401511fd3fda85